### PR TITLE
defining properties up front

### DIFF
--- a/src/Pdfgen.php
+++ b/src/Pdfgen.php
@@ -16,6 +16,11 @@ class Pdfgen {
      * @var PSR-3 Logger
      */
     private $logger;
+    
+    private $username;
+    private $password;
+    private $base_url;
+    private $tmp_path;
 
     /**
      * Pdfgen constructor.


### PR DESCRIPTION
Addresses PHP 8 complaints about dynamic properties being deprecated.